### PR TITLE
Properly parse doc strings and declaration in defgenerator

### DIFF
--- a/snakes.asd
+++ b/snakes.asd
@@ -5,7 +5,7 @@
   :description "Python style generators for Common Lisp."
   :author "Ben McGunigle <bnmcgn@gmail.com>"
   :license "Apache 2.0"
-  :depends-on (#:cl-cont #:closer-mop #:fiveam #:iterate #:cl-utilities)
+  :depends-on (#:cl-cont #:closer-mop #:fiveam #:iterate #:cl-utilities #:alexandria)
   :components ((:file "package")
 	       (:file "util")
                (:file "snakes" :depends-on ("util"))

--- a/snakes.lisp
+++ b/snakes.lisp
@@ -62,9 +62,13 @@
 		  (apply #'values (funcall values-handler current)))))))))
 
 (defmacro defgenerator (name arguments &body body)
-  `(defun ,name ,arguments
-     (with-yield
-       ,@body)))
+  (multiple-value-bind (remaining-forms declarations doc-string)
+      (alexandria:parse-body body :documentation t)
+    `(defun ,name ,arguments
+       ,doc-string
+       ,@declarations
+       (with-yield
+	 ,@remaining-forms))))
 
 (defmacro if-generator ((var gen) true-clause &optional false-clause)
   "Pulls a single iteration out of gen. If a single var is specified, it places all the values from the iteration in a list under var. If var is a list, destructures values into the vars in the list. If the generator has stopped, evaluates false-clause, otherwise evaluates true-clause."


### PR DESCRIPTION
+ Adds a new dependency: alexandria
+ Allows for the functions generated by this macro to have declaration
  forms and docstrings.